### PR TITLE
navigation wheel - consistency across pages, scaling heads, origin point

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -5,6 +5,7 @@ const addImage = require("./cfg/addImage")
 const addRand = require("./cfg/addRand")
 const addSass = require("./cfg/addSass")
 const addStringFilters = require("./cfg/addStringFilters")
+const addRemoveTrailingSlash = require("./cfg/addRemoveTrailingSlash")
 
 // -- config --
 module.exports = function (config) {
@@ -25,6 +26,7 @@ module.exports = function (config) {
   addRand(config)
   addSass(config)
   addStringFilters(config)
+  addRemoveTrailingSlash(config)
 
   // -- output --
   return {

--- a/cfg/addRemoveTrailingSlash.js
+++ b/cfg/addRemoveTrailingSlash.js
@@ -1,0 +1,16 @@
+module.exports = function (config) {
+  // -- remove trailing slash --
+  // not exactly web standard, but works fine
+  // https://www.11ty.dev/docs/permalinks/#trailing-slashes
+  // Set global permalinks to resource.html style
+  config.addGlobalData("permalink", () => {
+    return (data) =>
+      `${data.page.filePathStem}.${data.page.outputFileExtension}`
+  })
+  // Remove .html from `page.url` entries
+  config.addUrlTransform((page) => {
+    if (page.url.endsWith(".html")) {
+      return page.url.slice(0, -1 * ".html".length)
+    }
+  })
+}

--- a/src/_includes/home.scss
+++ b/src/_includes/home.scss
@@ -1,25 +1,7 @@
 /* -- Home -- */
 .Events {
-  .Nav {
-    --radius: 100px;
-
-    &-links {
-      animation: Rotate 100s linear infinite;
-    }
-  }
-
   &-eventList {
     margin-top: $spacing5;
-  }
-}
-
-@keyframes Rotate {
-  from {
-    transform: rotate(0deg);
-  }
-
-  to {
-    transform: rotate(359deg);
   }
 }
 

--- a/src/_includes/landing.scss
+++ b/src/_includes/landing.scss
@@ -3,8 +3,8 @@
   justify-content: center;
   align-items: center;
 
-  .Nav {
-    --radius: 200px;
+  & ~ .Nav {
+    --scale: 2;
 
     display: flex;
     justify-content: center;

--- a/src/_includes/nav.scss
+++ b/src/_includes/nav.scss
@@ -1,7 +1,8 @@
 @use "sass:math";
 
 .Nav {
-  --radius: 150px;
+  $radius: 100px;
+  --scale: 1;
 
   position: fixed;
   width: 100%;
@@ -10,17 +11,26 @@
   left: 0;
   pointer-events: none;
 
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
   &-links {
     position: relative;
     display: flex;
     justify-content: center;
     align-items: center;
-    width: calc(var(--radius) * 2);
-    height: calc(var(--radius) * 2);
+    width: calc($radius * var(--scale) * 2);
+    height: calc($radius * var(--scale) * 2);
 
     > ul {
       display: contents;
+      .Boshi {
+        transform: scale(calc(var(--scale) * 0.5));
+      }
     }
+
+    animation: Rotate 100s linear infinite;
   }
 
   &-item {
@@ -34,8 +44,8 @@
     @for $i from 0 to $n + 1 {
       &:nth-child(#{$i + 1}) {
         transform: translate(
-          calc(var(--radius) * cos($i * #{$a}deg)),
-          calc(var(--radius) * sin($i * #{$a}deg))
+          calc($radius * var(--scale) * cos($i * #{$a}deg)),
+          calc($radius * var(--scale) * sin($i * #{$a}deg))
         );
       }
     }
@@ -69,5 +79,15 @@
         (math.random() - 0.5) * 2 * 60px
       );
     }
+  }
+}
+
+@keyframes Rotate {
+  from {
+    transform: rotate(0deg);
+  }
+
+  to {
+    transform: rotate(360deg);
   }
 }

--- a/src/_layouts/Page.liquid
+++ b/src/_layouts/Page.liquid
@@ -48,9 +48,8 @@
   <body>
     <div id="page" class="Page {{ section | camelize }}">
       {{ content }}
-      {% render "nav/Nav" %}
     </div>
-
+    {% render "nav/Nav" %}
     <div id="loading" class="Loading"></div>
   </body>
 </html>


### PR DESCRIPTION
changelog:
- remove trailing slash from URL so that relative img links continue to work (bug fix)
- navigation wheel remains on the dom on page loads, id="page" gets patched
- navigation wheel scale is consistent across pages

![image](https://github.com/user-attachments/assets/c50a348a-c1c7-453c-a4e6-3ce5e79c5f5b)
![image](https://github.com/user-attachments/assets/b8a21856-285c-49ea-bebb-5f183d472df7)
