### PR TITLE
add more image sizes to account for screen density

### DIFF
--- a/cfg/addImage.js
+++ b/cfg/addImage.js
@@ -23,7 +23,7 @@ module.exports = function (config, srcDir, dstDir) {
       }
 
       const meta = await Image(src, {
-        widths: [200, "auto"],
+        widths: [200, 400, 600, 1200, "auto"],
         formats: isRemoteUrl ? ["jpeg"] : ["auto"],
         urlPath: "/img",
         outputDir: `./${dstDir}/img/`,

--- a/src/_includes/event-detail.scss
+++ b/src/_includes/event-detail.scss
@@ -3,13 +3,59 @@
     max-width: $desktop-max;
   }
 
+  &-header {
+    display: flex;
+    flex-direction: column-reverse;
+  }
+
+  &-titleRow {
+    margin-top: $spacing0;
+    transform: rotate(calc(-3deg + var(--rand) * 6deg));
+  }
+
   &-title {
+    display: inline;
     font-size: $font-size4;
     text-shadow: $color-shadow1 3px 0 4px;
-    transform: rotate(calc(-3deg + var(--rand) * 6deg));
 
     @mixin desktop {
       font-size: $font-size5;
+    }
+  }
+
+  &-ticketsButton {
+    @include background($riso: 5, $color: $coral);
+
+    cursor: pointer;
+    display: inline-block;
+    margin-left: $spacing1;
+    padding: $spacing1 $spacing3;
+    vertical-align: text-bottom;
+    color: $white;
+    border-radius: $radius0;
+    box-shadow: rgba($black, 0.5) 0 0 8px 0px;
+
+    &:hover {
+      background-color: $blue0;
+      animation: Shake 0.3s linear infinite;
+    }
+
+    @keyframes Shake {
+      0% {
+        transform: translateX(+0px);
+      }
+
+      25% {
+        transform: translateX(-1px) rotate(-0.5deg);
+      }
+
+      75% {
+        transform: translateX(+1px) rotate(+0.5deg);
+      }
+
+      100% {
+        transform: translateX(+0px);
+      }
     }
   }
 

--- a/src/_includes/event-detail/EventDetail.liquid
+++ b/src/_includes/event-detail/EventDetail.liquid
@@ -1,7 +1,16 @@
 <article class="EventDetail-body">
-  <h1 class="EventDetail-title" style="{% randvar %}">
-    {{ name }}
-  </h1>
+  <header class="EventDetail-header">
+    <span class="EventDetail-titleRow" style="{% randvar %}">
+      <h1 class="EventDetail-title"">
+        {{ name }}
+      </h1>
+
+      {% assign url = links.tickets %}
+      {% if url != null %}
+        <a class="EventDetail-ticketsButton" href="{{ url }}" {{ url | toExternalLinkAttrs }}>rsvp!</a>
+      {% endif %}
+    </span>
+  </header>
 
   <h2 class="EventDetail-date" style="{% randvar %}">
     {{ date | toLongDate }}

--- a/src/_includes/event-detail/EventDetail.liquid
+++ b/src/_includes/event-detail/EventDetail.liquid
@@ -8,7 +8,7 @@
   </h2>
 
   <figure class="EventDetail-posterFrame" style="{% randvar %}">
-    {% img poster "(max-width: 200px)" %}
+    {% img poster "600px" %}
   </figure>
 
   <section class="EventDetail-content" style="{% randvar %}">

--- a/src/_includes/events.scss
+++ b/src/_includes/events.scss
@@ -113,6 +113,7 @@ $list: null;
 
   &-anchor {
     display: contents;
+    color: $black;
   }
 
   &-poster {

--- a/src/_includes/events/EventCard.liquid
+++ b/src/_includes/events/EventCard.liquid
@@ -32,7 +32,7 @@
           <rect class="EventCardBorder-shape" />
         </svg>
 
-        {% img event.data.poster "(max-width: 200px)" %}
+        {% img event.data.poster "200px" %}
       </figure>
     </div>
 

--- a/src/site.scss
+++ b/src/site.scss
@@ -31,16 +31,7 @@ a:not([class]) {
 }
 
 a[class] {
-  color: unset;
   text-decoration: unset;
-
-  &:hover {
-    color: unset;
-  }
-
-  &:visited {
-    color: unset;
-  }
 }
 
 /* -- Page -- */


### PR DESCRIPTION
fixes the events page image tags requesting full size images.

of the sizes we generate here:

```js
widths: [200, 400, 600, 1200, "auto"]
```

the `img` shortcode generates an `<img>` tag with [`srcset`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/srcset) and [`sizes`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/sizes) that attempts to pick the size that best matches the size query it's passed. a query of `200px` should match the `200` image:

```liquid
{% img event.data.poster "200px" %}
```

however, when the browser does this comparison it accounts for pixel density, so on a 2x screen (like a macbook), a query of `200px` is actually `400px`. so it picks `400` or the next biggest size, which used to be `auto`, which was full size.